### PR TITLE
Explicitly set rails namespace to avoid undefined constant errors

### DIFF
--- a/lib/generators/backbone/collection_generator.rb
+++ b/lib/generators/backbone/collection_generator.rb
@@ -2,7 +2,7 @@
 require 'rails/generators'
 
 module Backbone
-  class CollectionGenerator < Rails::Generators::Base
+  class CollectionGenerator < ::Rails::Generators::Base
     source_root File.expand_path('../templates', __FILE__)
     desc "Creates a BackboneModel, BackboneCollection, & Jasmine tests/factory\nrails g backbone:collection Navigation::Buttons"
     argument :raw_collection_name, required: true, type: 'string'

--- a/lib/generators/backbone/model_generator.rb
+++ b/lib/generators/backbone/model_generator.rb
@@ -2,7 +2,7 @@
 require 'rails/generators'
 
 module Backbone
-  class ModelGenerator < Rails::Generators::Base
+  class ModelGenerator < ::Rails::Generators::Base
     source_root File.expand_path('../templates', __FILE__)
     desc "Creates a BackboneModel, Jasmine tests/factory"
     argument :raw_model_name, required: true, type: 'string'

--- a/lib/generators/backbone/namespace_generator.rb
+++ b/lib/generators/backbone/namespace_generator.rb
@@ -3,7 +3,7 @@ require 'rails/generators'
 require 'find'
 
 module Backbone
-  class NamespaceGenerator < Rails::Generators::Base
+  class NamespaceGenerator < ::Rails::Generators::Base
     source_root File.expand_path('../templates', __FILE__)
     desc "Setup a Backbone namespace"
     argument :raw_namespace, :type => :string, :required => true

--- a/lib/generators/backbone/setup_generator.rb
+++ b/lib/generators/backbone/setup_generator.rb
@@ -2,7 +2,7 @@
 require 'rails/generators'
 
 module Backbone
-  class SetupGenerator < Rails::Generators::Base
+  class SetupGenerator < ::Rails::Generators::Base
     source_root File.expand_path('../setup_generator/templates', __FILE__)
     desc "Setup a Backbone Application"
     


### PR DESCRIPTION
Avoids `Undefined constant Backbone::Rails::Generators`
